### PR TITLE
Fix test failures by updating mocks, serialization, and cache tests

### DIFF
--- a/src/test/kotlin/com/terragon/kotlinffetch/AEMResponseBuilder.kt
+++ b/src/test/kotlin/com/terragon/kotlinffetch/AEMResponseBuilder.kt
@@ -15,7 +15,7 @@ class AEMResponseBuilder {
     private var total: Int = 0
     private var offset: Int = 0
     private var limit: Int = 255
-    private val data = mutableListOf<Map<String, Any>>()
+    private val data = mutableListOf<Map<String, Any?>>()
     
     companion object {
         /**
@@ -258,9 +258,9 @@ class AEMResponseBuilder {
     fun addSheetItem(
         path: String,
         sheet: String,
-        additionalData: Map<String, Any>
+        additionalData: Map<String, Any?>
     ): AEMResponseBuilder {
-        val entry = mutableMapOf<String, Any>(
+        val entry = mutableMapOf<String, Any?>(
             "path" to path,
             "sheet" to sheet
         )

--- a/src/test/kotlin/com/terragon/kotlinffetch/CacheTestHelper.kt
+++ b/src/test/kotlin/com/terragon/kotlinffetch/CacheTestHelper.kt
@@ -10,8 +10,11 @@ package com.terragon.kotlinffetch.mock
 import com.terragon.kotlinffetch.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import io.ktor.util.*
+import kotlinx.coroutines.*
 import kotlin.collections.mutableMapOf
 import kotlin.collections.mutableSetOf
+import kotlin.coroutines.CoroutineContext
 
 /**
  * Mock cache implementation for testing cache behavior
@@ -158,7 +161,9 @@ class CacheAwareTestHTTPClient(
     }
     
     private fun createResponse(content: String, statusCode: HttpStatusCode): Pair<String, HttpResponse> {
+        @OptIn(InternalAPI::class)
         val mockResponse = object : HttpResponse() {
+            override val coroutineContext: CoroutineContext = Job()
             override val call: io.ktor.client.call.HttpClientCall
                 get() = throw NotImplementedError()
             override val content: io.ktor.utils.io.ByteReadChannel

--- a/src/test/kotlin/com/terragon/kotlinffetch/cache/CacheBehaviorTest.kt
+++ b/src/test/kotlin/com/terragon/kotlinffetch/cache/CacheBehaviorTest.kt
@@ -9,14 +9,20 @@ package com.terragon.kotlinffetch.cache
 
 import com.terragon.kotlinffetch.*
 import com.terragon.kotlinffetch.mock.MockFFetchHTTPClient
-import io.ktor.http.*
+import com.terragon.kotlinffetch.mock.MockResponse
+import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.test.runTest
 import kotlin.test.*
+import java.net.URL
 
 class CacheBehaviorTest {
     
     private fun createMockClient(responses: Map<String, String> = mapOf()): MockFFetchHTTPClient {
-        return MockFFetchHTTPClient(responses)
+        val client = MockFFetchHTTPClient()
+        responses.forEach { (url, content) ->
+            client.setResponse(url, MockResponse.success(content))
+        }
+        return client
     }
     
     @Test
@@ -161,7 +167,7 @@ class CacheBehaviorTest {
             cacheConfig = FFetchCacheConfig.Default
         )
         
-        val ffetch = FFetch("https://example.com/test.json", originalContext)
+        val ffetch = FFetch(URL("https://example.com/test.json"), originalContext)
         val modifiedFFetch = ffetch.cache(FFetchCacheConfig.CacheOnly)
         
         // Verify that only cache config changed, other properties preserved

--- a/src/test/kotlin/com/terragon/kotlinffetch/http/CustomClientTest.kt
+++ b/src/test/kotlin/com/terragon/kotlinffetch/http/CustomClientTest.kt
@@ -10,7 +10,10 @@ package com.terragon.kotlinffetch.http
 import com.terragon.kotlinffetch.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import io.ktor.util.*
+import kotlinx.coroutines.*
 import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.CoroutineContext
 import kotlin.test.*
 
 class CustomClientTest {
@@ -48,7 +51,9 @@ class CustomClientTest {
             
             // Create a mock HttpResponse - this is simplified for testing
             // In real implementation, we'd need to create a proper HttpResponse mock
+            @OptIn(InternalAPI::class)
             val mockResponse = object : HttpResponse() {
+                override val coroutineContext: CoroutineContext = Job()
                 override val call: io.ktor.client.call.HttpClientCall
                     get() = throw NotImplementedError()
                 override val content: io.ktor.utils.io.ByteReadChannel

--- a/src/test/kotlin/com/terragon/kotlinffetch/http/DefaultFFetchHTTPClientTest.kt
+++ b/src/test/kotlin/com/terragon/kotlinffetch/http/DefaultFFetchHTTPClientTest.kt
@@ -11,8 +11,10 @@ import com.terragon.kotlinffetch.*
 import io.ktor.client.*
 import io.ktor.client.engine.mock.*
 import io.ktor.client.plugins.*
+import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.utils.io.*
+import kotlinx.coroutines.*
 import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 import kotlin.time.Duration.Companion.seconds
@@ -227,7 +229,7 @@ class DefaultFFetchHTTPClientTest {
         val urls = (1..5).map { "https://example.com/path$it" }
         
         val results = urls.map { url ->
-            kotlinx.coroutines.async {
+            async {
                 client.fetch(url)
             }
         }.map { it.await() }

--- a/src/test/kotlin/com/terragon/kotlinffetch/serialization/DataTypeConversionTest.kt
+++ b/src/test/kotlin/com/terragon/kotlinffetch/serialization/DataTypeConversionTest.kt
@@ -299,7 +299,7 @@ class DataTypeConversionTest {
         assertEquals("null", entry["stringNull"]?.toString())
         assertNull(entry["actualNull"])
         assertEquals(123, entry["leadingZeros"]?.toString()?.toIntOrNull())
-        assertEquals(0.000123, entry["scientificNotation"]?.toString()?.toDoubleOrNull(), 0.0000001)
+        assertEquals(0.000123, entry["scientificNotation"]?.toString()?.toDoubleOrNull() ?: 0.0, 0.0000001)
     }
 
     @Test

--- a/src/test/kotlin/com/terragon/kotlinffetch/serialization/FFetchResponseSerializationTest.kt
+++ b/src/test/kotlin/com/terragon/kotlinffetch/serialization/FFetchResponseSerializationTest.kt
@@ -129,7 +129,7 @@ class FFetchResponseSerializationTest {
         val entry = response.data[0]
         assertEquals("Test Article", (entry["title"] as JsonPrimitive).content)
         assertEquals("some value", (entry["futureField"] as JsonPrimitive).content)
-        assertEquals(42, (entry["anotherNewField"] as JsonPrimitive).int)
+        assertEquals(42, (entry["anotherNewField"] as JsonPrimitive).content.toInt())
     }
 
     @Test

--- a/src/test/kotlin/com/terragon/kotlinffetch/serialization/RealWorldDataTest.kt
+++ b/src/test/kotlin/com/terragon/kotlinffetch/serialization/RealWorldDataTest.kt
@@ -167,8 +167,8 @@ class RealWorldDataTest {
                                     putJsonObject("level5") {
                                         put("deepValue", "found at level 5")
                                         putJsonArray("deepArray") {
-                                            add("item1")
-                                            add("item2")
+                                            add(JsonPrimitive("item1"))
+                                            add(JsonPrimitive("item2"))
                                         }
                                     }
                                 }
@@ -333,9 +333,9 @@ class RealWorldDataTest {
                 put("publishDate", "2024-01-${(index % 28) + 1}T${(index % 24).toString().padStart(2, '0')}:00:00.000Z")
                 put("lastModified", "2024-01-${(index % 28) + 1}T${(index % 24).toString().padStart(2, '0')}:30:00.000Z")
                 putJsonArray("tags") {
-                    add("tag${index % 10}")
-                    add("category${index % 5}")
-                    if (index % 3 == 0) add("featured")
+                    add(JsonPrimitive("tag${index % 10}"))
+                    add(JsonPrimitive("category${index % 5}"))
+                    if (index % 3 == 0) add(JsonPrimitive("featured"))
                 }
                 putJsonObject("metadata") {
                     put("template", "article-template")


### PR DESCRIPTION
## Summary
- Fixes multiple test failures across cache, HTTP client, and serialization tests
- Updates mock HTTP responses to properly implement coroutine context
- Adjusts data types in AEMResponseBuilder and serialization tests for nullability and type safety
- Refactors cache behavior tests to use URL objects and improved mock responses
- Corrects JSON primitive handling in serialization and real-world data tests

## Changes

### Test Infrastructure
- Added coroutine context overrides in mock HttpResponse implementations for CustomClientTest and CacheTestHelper
- Updated CacheBehaviorTest to initialize mock client responses with `MockResponse.success` and use `URL` instead of string URLs

### Code and Test Fixes
- Changed mutable list type in AEMResponseBuilder from `Map<String, Any>` to `Map<String, Any?>` to handle nullable values
- Fixed type conversions in DataTypeConversionTest and FFetchResponseSerializationTest to avoid unsafe casts
- Updated JSON array additions in RealWorldDataTest to wrap strings in `JsonPrimitive` for proper serialization
- Refined coroutine usage in DefaultFFetchHTTPClientTest to use `async` from the current coroutine scope

## Test plan
- [x] Run all unit tests to verify fixes
- [x] Confirm no regressions in cache behavior and HTTP client tests
- [x] Validate serialization tests pass with updated JSON handling
- [x] Ensure mock responses correctly simulate HTTP responses with coroutine context

This PR addresses flaky and failing tests by improving mocks, type safety, and serialization handling to ensure stable and reliable test execution.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/d4c96df5-fb71-4ccf-b517-59f7a6ccc49e