### PR TITLE
Fix early termination in pagination flow by handling cancellation properly

### DIFF
--- a/src/main/kotlin/com/terragon/kotlinffetch/FFetch.kt
+++ b/src/main/kotlin/com/terragon/kotlinffetch/FFetch.kt
@@ -10,6 +10,7 @@ package com.terragon.kotlinffetch
 import com.terragon.kotlinffetch.internal.FFetchRequestHandler
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import java.net.URL
@@ -55,6 +56,7 @@ class FFetch(
                 }
             } catch (e: Exception) {
                 throw when (e) {
+                    is CancellationException -> e // Let cancellation exceptions propagate
                     is FFetchError -> e
                     else -> FFetchError.OperationFailed(e.message ?: "Unknown error")
                 }

--- a/src/main/kotlin/com/terragon/kotlinffetch/internal/FFetchRequestHandler.kt
+++ b/src/main/kotlin/com/terragon/kotlinffetch/internal/FFetchRequestHandler.kt
@@ -48,10 +48,12 @@ internal object FFetchRequestHandler {
                 mutableContext.total = fetchResponse.total
             }
             
-            // Emit entries
+            // Emit entries (check for cancellation between each emit)
             val entries = fetchResponse.toFFetchEntries()
             for (entry in entries) {
                 emit(entry)
+                // The emit function will throw CancellationException 
+                // if the flow collection has been cancelled
             }
             
             // Check if we've reached the end


### PR DESCRIPTION
## Summary
- Fixes premature termination of pagination flow due to improper handling of cancellation exceptions
- Ensures `CancellationException` propagates correctly during flow emission
- Improves pagination integration test to use flow operators for early termination

## Changes

### Core Fixes
- In `FFetch.kt`, added handling to rethrow `CancellationException` to allow proper coroutine cancellation
- In `FFetchRequestHandler.kt`, added comments and ensured cancellation is checked between each emitted entry in the flow

### Tests
- Updated `PaginationIntegrationTest.kt` to use `take(150).toList()` instead of manual collection and early return for better flow cancellation handling
- Adjusted test setup to use consistent chunk sizes

## Test plan
- Verified pagination integration tests pass with early termination using flow operators
- Confirmed no premature termination or swallowed cancellation exceptions during pagination flow collection

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f0dd7f13-c827-4b2f-a6fd-16a3da9c55e1