### PR TITLE
Fix allowedHosts handling for hostnames with ports

### DIFF
--- a/src/main/kotlin/com/terragon/kotlinffetch/FFetch.kt
+++ b/src/main/kotlin/com/terragon/kotlinffetch/FFetch.kt
@@ -35,9 +35,15 @@ class FFetch(
     )
     
     init {
-        // Set the initial hostname as allowed if no hosts are explicitly allowed
-        if (context.allowedHosts.isEmpty()) {
-            url.host?.let { context.allowedHosts.add(it) }
+        // Add the URL's hostname or hostname:port to allowed hosts based on the port
+        url.host?.let { hostname ->
+            if (url.port != -1) {
+                // For non-default ports, add hostname:port
+                context.allowedHosts.add("${hostname}:${url.port}")
+            } else {
+                // For default ports, add hostname only
+                context.allowedHosts.add(hostname)
+            }
         }
     }
     

--- a/src/main/kotlin/com/terragon/kotlinffetch/extensions/FFetchDocumentFollowing.kt
+++ b/src/main/kotlin/com/terragon/kotlinffetch/extensions/FFetchDocumentFollowing.kt
@@ -194,9 +194,16 @@ private fun FFetch.isHostnameAllowed(url: URL): Boolean {
         return true
     }
     
-    // Allow if hostname matches any in the allowlist
-    val hostname = url.host
-    return hostname?.let { context.allowedHosts.contains(it) } ?: false
+    val hostname = url.host ?: return false
+    
+    // For non-default ports, require explicit hostname:port permission
+    if (url.port != -1) {
+        val hostnameWithPort = "${hostname}:${url.port}"
+        return context.allowedHosts.contains(hostnameWithPort)
+    }
+    
+    // For default ports, check for hostname-only permission
+    return context.allowedHosts.contains(hostname)
 }
 
 // MARK: - Hostname Security Configuration


### PR DESCRIPTION
## Summary
- Corrects the handling of allowed hosts to include port numbers when non-default ports are used
- Ensures hostname checks respect port information for security

## Changes

### Core Functionality
- **FFetch Initialization**: Modified to add `hostname:port` to `allowedHosts` if the URL uses a non-default port, otherwise just the hostname is added
- **Hostname Allowance Check**: Updated logic to verify if the hostname with port is explicitly allowed when a non-default port is present, falling back to hostname-only check for default ports

## Test plan
- Verify that URLs with default ports add only the hostname to allowed hosts
- Verify that URLs with non-default ports add `hostname:port` to allowed hosts
- Confirm that `isHostnameAllowed` returns true only if the exact hostname or hostname:port is in the allowed hosts
- Test with various URLs to ensure correct permission checks based on port presence

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/798112d8-5fe2-4e1b-a530-637b1bdef1aa