### PR TITLE
Fix boolean assertion and improve JSON primitive handling in RealWorldDataTest

### DIFF
--- a/src/main/kotlin/com/terragon/kotlinffetch/KotlinFFetchTypes.kt
+++ b/src/main/kotlin/com/terragon/kotlinffetch/KotlinFFetchTypes.kt
@@ -23,6 +23,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 
@@ -47,7 +48,22 @@ data class FFetchResponse(
     fun toFFetchEntries(): List<FFetchEntry> {
         return data.map { jsonObject ->
             jsonObject.entries.associate { (key, value) ->
-                key to value.toString().removeSurrounding("\"")
+                key to when (value) {
+                    is JsonPrimitive -> {
+                        if (value.isString) {
+                            // For string primitives, use the content directly 
+                            // This preserves escaped characters from JSON parsing
+                            value.content
+                        } else {
+                            // For non-string primitives, convert to string
+                            value.toString()
+                        }
+                    }
+                    else -> {
+                        // For non-primitives (arrays, objects), use toString and remove quotes
+                        value.toString().removeSurrounding("\"")
+                    }
+                }
             }
         }
     }

--- a/src/test/kotlin/com/terragon/kotlinffetch/serialization/RealWorldDataTest.kt
+++ b/src/test/kotlin/com/terragon/kotlinffetch/serialization/RealWorldDataTest.kt
@@ -418,7 +418,7 @@ class RealWorldDataTest {
         // Test special characters
         val specialCharsEntry = entries[0]
         assertTrue((specialCharsEntry["title"] as String).contains("\"quotes\""))
-        assertTrue((specialCharsEntry["content"] as String).contains("\\n"))
+        assertTrue((specialCharsEntry["content"] as String).contains("\n"))
         assertTrue((specialCharsEntry["url"] as String).contains("?param=value"))
 
         // Test empty/null fields


### PR DESCRIPTION
## Summary
- Fixes incorrect boolean assertion in RealWorldDataTest for newline character check
- Enhances JSON primitive handling in FFetchResponse to preserve string content accurately

## Changes

### Core Functionality
- Updated `toFFetchEntries` method in `FFetchResponse` to handle `JsonPrimitive` types distinctly:
  - Preserves string content directly for string primitives to maintain escaped characters
  - Converts non-string primitives to string normally
  - Removes surrounding quotes only for non-primitive JSON elements

### Tests
- Corrected assertion in `RealWorldDataTest` to check for actual newline character (`\n` replaced with `\n` interpreted as newline) in content field

## Test plan
- [x] Verified that string primitives retain escaped characters correctly
- [x] Confirmed boolean assertion in test now correctly checks for newline character
- [x] Ran existing tests to ensure no regressions in JSON parsing and test validations

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/0b33964d-e1f8-4fc3-b94a-28a89620daa8