### PR TITLE
Fix JSON string escaping in FFetchResponse toFFetchEntries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KotlinFFetch
 
-[![79% Vibe_Coded](https://img.shields.io/badge/79%25-Vibe_Coded-ff69b4?style=for-the-badge&logo=zedindustries&logoColor=white)](https://github.com/trieloff/vibe-coded-badge-action)
+[![9% Vibe_Coded](https://img.shields.io/badge/9%25-Vibe_Coded-ff69b4?style=for-the-badge&logo=claude&logoColor=white)](https://github.com/trieloff/vibe-coded-badge-action)
 
 [![codecov](https://img.shields.io/codecov/c/github/trieloff/koffetch?token=SROMISB0K5&style=for-the-badge&logo=codecov&logoColor=white)](https://codecov.io/gh/trieloff/koffetch)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/trieloff/koffetch/test.yaml?style=for-the-badge&logo=github)](https://github.com/trieloff/koffetch/actions)

--- a/src/main/kotlin/com/terragon/kotlinffetch/KotlinFFetchTypes.kt
+++ b/src/main/kotlin/com/terragon/kotlinffetch/KotlinFFetchTypes.kt
@@ -23,6 +23,8 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 
@@ -47,7 +49,14 @@ data class FFetchResponse(
     fun toFFetchEntries(): List<FFetchEntry> {
         return data.map { jsonObject ->
             jsonObject.entries.associate { (key, value) ->
-                key to value.toString().removeSurrounding("\"")
+                key to when (value) {
+                    is JsonPrimitive -> {
+                        val content = value.contentOrNull ?: "null"
+                        // Remove surrounding quotes if they exist (handles literal quote characters in buildJsonObject)
+                        content.removeSurrounding("\"")
+                    }
+                    else -> value.toString()
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Fixes JSON string escaping issue in `FFetchResponse.toFFetchEntries` method
- Properly handles `JsonPrimitive` values by removing surrounding quotes only when necessary
- Prevents incorrect string representation of JSON values

## Changes

### Core Functionality
- Updated `toFFetchEntries` to check if a JSON value is a `JsonPrimitive`
- Extracts content safely using `contentOrNull` and removes surrounding quotes if present
- Falls back to default `toString()` for other JSON element types

## Test plan
- [ ] Verify that JSON strings are correctly unescaped without extra quotes
- [ ] Test with various JSON primitives including strings, numbers, booleans, and nulls
- [ ] Confirm no regressions in JSON parsing and mapping to `FFetchEntry`

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b49f2937-615d-4c86-867c-b281cb3383cb