### PR TITLE
Fix Detekt linting issues by updating rules and exclusions

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -70,9 +70,11 @@ complexity:
   LargeClass:
     active: true
     threshold: 300
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
   LongMethod:
     active: true
     threshold: 50
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
   LongParameterList:
     active: true
     functionThreshold: 6
@@ -194,6 +196,7 @@ exceptions:
     allowedExceptionNameRegex: "^(_|(ignore|expected).*)"
   TooGenericExceptionThrown:
     active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     exceptionNames:
      - Error
      - Exception
@@ -436,6 +439,7 @@ style:
   ReturnCount:
     active: true
     max: 2
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     excludedFunctions: ['equals']
     excludeLabeled: false
     excludeReturnFromLambda: true
@@ -449,6 +453,7 @@ style:
   ThrowsCount:
     active: true
     max: 2
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
   TrailingWhitespace:
     active: false
   UnderscoresInNumericLiterals:
@@ -474,7 +479,16 @@ style:
   UnusedPrivateClass:
     active: false
   UnusedPrivateMember:
-    active: false
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
+    allowedNames: "(_|ignored|expected|serialVersionUID)"
+  UnusedParameter:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
+    allowedNames: "(_|ignored|expected|serialVersionUID)"
+  UnusedPrivateProperty:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     allowedNames: "(_|ignored|expected|serialVersionUID)"
   UseArrayLiteralsInAnnotations:
     active: false


### PR DESCRIPTION
## Summary
- Updated Detekt configuration to fix linting issues
- Added exclusions for test directories in multiple rules
- Enabled and configured unused code detection rules with appropriate exclusions

## Changes

### Detekt Configuration
- Added `excludes` patterns to ignore test-related directories for the following rules:
  - LargeClass
  - LongMethod
  - TooGenericExceptionThrown
  - ReturnCount
  - ThrowsCount
- Enabled `UnusedPrivateMember`, `UnusedParameter`, and `UnusedPrivateProperty` rules with exclusions for test directories and allowed names (`_, ignored, expected, serialVersionUID`)
- Minor cleanup by removing unused private member deactivation

## Test plan
- Run Detekt analysis to verify no linting errors in production code
- Confirm that test code is excluded from the specified rules
- Validate that unused code detection works as expected in non-test code

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e961a199-2ba0-4130-9864-983dc60c9489