### PR TITLE
Refine exception handling in FFetch for URL validation and request errors

### DIFF
--- a/src/main/kotlin/live/aem/koffetch/FFetch.kt
+++ b/src/main/kotlin/live/aem/koffetch/FFetch.kt
@@ -40,11 +40,10 @@ class FFetch(
             // Validate the URL string before attempting to create URL object
             validateURLString(url)
             URL(url)
-        } catch (e: Exception) {
-            when (e) {
-                is MalformedURLException, is IllegalArgumentException -> throw FFetchError.InvalidURL(url)
-                else -> throw e
-            }
+        } catch (e: MalformedURLException) {
+            throw FFetchError.InvalidURL(url)
+        } catch (e: IllegalArgumentException) {
+            throw FFetchError.InvalidURL(url)
         },
     )
 
@@ -114,12 +113,10 @@ class FFetch(
                 FFetchRequestHandler.performRequest(url, context) { entry ->
                     emit(entry)
                 }
-            } catch (e: Exception) {
-                throw when (e) {
-                    is CancellationException -> e // Let cancellation exceptions propagate
-                    is FFetchError -> e
-                    else -> FFetchError.OperationFailed(e.message ?: "Unknown error")
-                }
+            } catch (e: java.io.IOException) {
+                throw FFetchError.NetworkError(e)
+            } catch (e: kotlinx.serialization.SerializationException) {
+                throw FFetchError.DecodingError(e)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Improved exception handling in `FFetch` class for better error specificity
- Separated catch blocks for URL validation to throw `FFetchError.InvalidURL` explicitly
- Enhanced request error handling to distinguish between network and decoding errors

## Changes

### URL Validation
- Replaced generic `Exception` catch with specific catches for `MalformedURLException` and `IllegalArgumentException`
- Both exceptions now throw `FFetchError.InvalidURL` with the invalid URL

### Request Execution
- Removed generic `Exception` catch block
- Added specific catches for `java.io.IOException` to throw `FFetchError.NetworkError`
- Added catch for `kotlinx.serialization.SerializationException` to throw `FFetchError.DecodingError`
- Allowed `CancellationException` and `FFetchError` to propagate without wrapping

## Test plan
- [ ] Validate that malformed URLs throw `FFetchError.InvalidURL`
- [ ] Confirm network-related IO exceptions throw `FFetchError.NetworkError`
- [ ] Verify serialization exceptions throw `FFetchError.DecodingError`
- [ ] Ensure cancellation exceptions propagate correctly
- [ ] Run existing unit tests to confirm no regressions in request handling

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/3d0a48a5-e78f-4ec2-a64e-f9c05f1b52e0