### PR TITLE
Add comprehensive hostname security and error handling tests for FFetch

### DIFF
--- a/src/test/kotlin/live/aem/koffetch/extensions/FFetchDocumentFollowingTest.kt
+++ b/src/test/kotlin/live/aem/koffetch/extensions/FFetchDocumentFollowingTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.test.runTest
 import live.aem.koffetch.FFetch
 import live.aem.koffetch.FFetchContext
 import live.aem.koffetch.FFetchEntry
+import live.aem.koffetch.FFetchError
 import live.aem.koffetch.mock.MockFFetchHTTPClient
 import live.aem.koffetch.mock.MockHTMLParser
 import java.net.URL
@@ -602,6 +603,627 @@ class FFetchDocumentFollowingTest {
             // The exact behavior of concurrency limiting is internal,
             // but we can verify all requests were made
             assertEquals(7, mockHttpClient.requestLog.size) // 6 documents + 1 index
+        }
+
+    @Test
+    fun testHostnameSecurityRestrictions() =
+        runTest {
+            val crossDomainResponse =
+                mockHttpClient.createAEMResponse(
+                    total = 2,
+                    offset = 0,
+                    limit = 255,
+                    data =
+                        listOf(
+                            mapOf(
+                                "path" to "/content/external-1",
+                                "title" to "External Article 1",
+                                "documentUrl" to "https://external-domain.com/doc1.html",
+                            ),
+                            mapOf(
+                                "path" to "/content/external-2",
+                                "title" to "External Article 2",
+                                "documentUrl" to "https://another-domain.com/doc2.html",
+                            ),
+                        ),
+                )
+
+            mockHttpClient.setSuccessResponse(
+                "https://example.com/cross-domain.json?offset=0&limit=255",
+                crossDomainResponse,
+            )
+
+            val ffetch =
+                FFetch(
+                    URL("https://example.com/cross-domain.json"),
+                    FFetchContext(
+                        httpClient = mockHttpClient,
+                        htmlParser = mockHtmlParser,
+                    ),
+                )
+
+            val results = ffetch.follow("documentUrl").asFlow().toList()
+
+            assertEquals(2, results.size)
+
+            // Both entries should have security errors since external domains are not allowed
+            results.forEach { entry ->
+                assertNull(entry["documentUrl"])
+                val error = entry["documentUrl_error"] as? String
+                assertTrue(error?.contains("is not allowed for document following") == true)
+                assertTrue(error?.contains("Use .allow() to permit additional hostnames") == true)
+            }
+        }
+
+    @Test
+    fun testAllowSpecificHostname() =
+        runTest {
+            val externalResponse =
+                mockHttpClient.createAEMResponse(
+                    total = 1,
+                    offset = 0,
+                    limit = 255,
+                    data =
+                        listOf(
+                            mapOf(
+                                "path" to "/content/allowed-external",
+                                "title" to "Allowed External Article",
+                                "documentUrl" to "https://trusted-domain.com/doc.html",
+                            ),
+                        ),
+                )
+
+            mockHttpClient.setSuccessResponse(
+                "https://example.com/external.json?offset=0&limit=255",
+                externalResponse,
+            )
+
+            mockHttpClient.setSuccessResponse(
+                "https://trusted-domain.com/doc.html",
+                "<html><body><h1>Trusted Content</h1></body></html>",
+            )
+
+            val ffetch =
+                FFetch(
+                    URL("https://example.com/external.json"),
+                    FFetchContext(
+                        httpClient = mockHttpClient,
+                        htmlParser = mockHtmlParser,
+                    ),
+                )
+
+            val results = ffetch.allow("trusted-domain.com").follow("documentUrl").asFlow().toList()
+
+            assertEquals(1, results.size)
+
+            val entry = results.first()
+            assertNotNull(entry["documentUrl"])
+            assertNull(entry["documentUrl_error"])
+        }
+
+    @Test
+    fun testAllowMultipleHostnames() =
+        runTest {
+            val multipleExternalResponse =
+                mockHttpClient.createAEMResponse(
+                    total = 3,
+                    offset = 0,
+                    limit = 255,
+                    data =
+                        listOf(
+                            mapOf(
+                                "path" to "/content/trusted-1",
+                                "title" to "Trusted Article 1",
+                                "documentUrl" to "https://api.trusted.com/doc1.html",
+                            ),
+                            mapOf(
+                                "path" to "/content/trusted-2",
+                                "title" to "Trusted Article 2",
+                                "documentUrl" to "https://cdn.trusted.com/doc2.html",
+                            ),
+                            mapOf(
+                                "path" to "/content/blocked",
+                                "title" to "Blocked Article",
+                                "documentUrl" to "https://untrusted.com/doc.html",
+                            ),
+                        ),
+                )
+
+            mockHttpClient.setSuccessResponse(
+                "https://example.com/multiple.json?offset=0&limit=255",
+                multipleExternalResponse,
+            )
+
+            mockHttpClient.setSuccessResponse(
+                "https://api.trusted.com/doc1.html",
+                "<html><body><h1>API Content</h1></body></html>",
+            )
+
+            mockHttpClient.setSuccessResponse(
+                "https://cdn.trusted.com/doc2.html",
+                "<html><body><h1>CDN Content</h1></body></html>",
+            )
+
+            val ffetch =
+                FFetch(
+                    URL("https://example.com/multiple.json"),
+                    FFetchContext(
+                        httpClient = mockHttpClient,
+                        htmlParser = mockHtmlParser,
+                    ),
+                )
+
+            val results =
+                ffetch
+                    .allow(listOf("api.trusted.com", "cdn.trusted.com"))
+                    .follow("documentUrl")
+                    .asFlow()
+                    .toList()
+
+            assertEquals(3, results.size)
+
+            // First two should succeed
+            val trustedEntries = results.filter { it["path"].toString().startsWith("/content/trusted") }
+            trustedEntries.forEach { entry ->
+                assertNotNull(entry["documentUrl"])
+                assertNull(entry["documentUrl_error"])
+            }
+
+            // Third should be blocked
+            val blockedEntry = results.first { it["path"] == "/content/blocked" }
+            assertNull(blockedEntry["documentUrl"])
+            val error = blockedEntry["documentUrl_error"] as? String
+            assertTrue(error?.contains("untrusted.com") == true)
+            assertTrue(error?.contains("is not allowed") == true)
+        }
+
+    @Test
+    fun testAllowAllHostnamesWithWildcard() =
+        runTest {
+            val wildcardResponse =
+                mockHttpClient.createAEMResponse(
+                    total = 2,
+                    offset = 0,
+                    limit = 255,
+                    data =
+                        listOf(
+                            mapOf(
+                                "path" to "/content/any-1",
+                                "title" to "Any Domain 1",
+                                "documentUrl" to "https://random-domain-1.com/doc.html",
+                            ),
+                            mapOf(
+                                "path" to "/content/any-2",
+                                "title" to "Any Domain 2",
+                                "documentUrl" to "https://random-domain-2.org/doc.html",
+                            ),
+                        ),
+                )
+
+            mockHttpClient.setSuccessResponse(
+                "https://example.com/wildcard.json?offset=0&limit=255",
+                wildcardResponse,
+            )
+
+            mockHttpClient.setSuccessResponse(
+                "https://random-domain-1.com/doc.html",
+                "<html><body><h1>Random Content 1</h1></body></html>",
+            )
+
+            mockHttpClient.setSuccessResponse(
+                "https://random-domain-2.org/doc.html",
+                "<html><body><h1>Random Content 2</h1></body></html>",
+            )
+
+            val ffetch =
+                FFetch(
+                    URL("https://example.com/wildcard.json"),
+                    FFetchContext(
+                        httpClient = mockHttpClient,
+                        htmlParser = mockHtmlParser,
+                    ),
+                )
+
+            val results = ffetch.allow("*").follow("documentUrl").asFlow().toList()
+
+            assertEquals(2, results.size)
+
+            // Both should succeed with wildcard permission
+            results.forEach { entry ->
+                assertNotNull(entry["documentUrl"])
+                assertNull(entry["documentUrl_error"])
+            }
+        }
+
+    @Test
+    fun testPortSpecificHostnameValidation() =
+        runTest {
+            val portResponse =
+                mockHttpClient.createAEMResponse(
+                    total = 2,
+                    offset = 0,
+                    limit = 255,
+                    data =
+                        listOf(
+                            mapOf(
+                                "path" to "/content/port-8080",
+                                "title" to "Port 8080 Article",
+                                "documentUrl" to "https://api.example.com:8080/doc.html",
+                            ),
+                            mapOf(
+                                "path" to "/content/port-9000",
+                                "title" to "Port 9000 Article",
+                                "documentUrl" to "https://api.example.com:9000/doc.html",
+                            ),
+                        ),
+                )
+
+            mockHttpClient.setSuccessResponse(
+                "https://example.com/ports.json?offset=0&limit=255",
+                portResponse,
+            )
+
+            mockHttpClient.setSuccessResponse(
+                "https://api.example.com:8080/doc.html",
+                "<html><body><h1>Port 8080 Content</h1></body></html>",
+            )
+
+            val ffetch =
+                FFetch(
+                    URL("https://example.com/ports.json"),
+                    FFetchContext(
+                        httpClient = mockHttpClient,
+                        htmlParser = mockHtmlParser,
+                    ),
+                )
+
+            val results =
+                ffetch
+                    .allow("api.example.com:8080") // Only allow port 8080
+                    .follow("documentUrl")
+                    .asFlow()
+                    .toList()
+
+            assertEquals(2, results.size)
+
+            // Port 8080 should succeed
+            val port8080Entry = results.first { it["path"] == "/content/port-8080" }
+            assertNotNull(port8080Entry["documentUrl"])
+            assertNull(port8080Entry["documentUrl_error"])
+
+            // Port 9000 should be blocked
+            val port9000Entry = results.first { it["path"] == "/content/port-9000" }
+            assertNull(port9000Entry["documentUrl"])
+            val error = port9000Entry["documentUrl_error"] as? String
+            assertTrue(error?.contains("api.example.com:9000") == true)
+            assertTrue(error?.contains("is not allowed") == true)
+        }
+
+    @Test
+    fun testOutOfMemoryErrorHandling() =
+        runTest {
+            // Configure mock parser to throw OutOfMemoryError
+            val oomHtmlParser = MockHTMLParser()
+            oomHtmlParser.shouldThrowError = false
+            oomHtmlParser.reset()
+            oomHtmlParser.throwErrorOnNextParse("Simulated OOM during HTML parsing")
+            
+            // Override the parse method to throw OutOfMemoryError instead of IllegalArgumentException
+            val customParser = object : live.aem.koffetch.FFetchHTMLParser {
+                override fun parse(html: String): org.jsoup.nodes.Document {
+                    throw OutOfMemoryError("Simulated OOM during HTML parsing")
+                }
+            }
+
+            val ffetch =
+                FFetch(
+                    URL("https://example.com/query-index.json"),
+                    FFetchContext(
+                        httpClient = mockHttpClient,
+                        htmlParser = customParser,
+                    ),
+                )
+
+            val results = ffetch.follow("documentUrl").asFlow().toList()
+
+            assertEquals(3, results.size)
+
+            // Entries that had valid URLs should have OutOfMemoryError handling
+            val entriesWithUrls = results.filter { it.containsKey("documentUrl") && it["documentUrl"] is String }
+            entriesWithUrls.forEach { entry ->
+                assertNull(entry["documentUrl"])
+                val error = entry["documentUrl_error"] as? String
+                assertTrue(error?.contains("HTML parsing error") == true)
+                assertTrue(error?.contains("Simulated OOM during HTML parsing") == true)
+            }
+        }
+
+    @Test
+    fun testFFetchNetworkErrorHandling() =
+        runTest {
+            // Configure mock client to throw NetworkError
+            val networkErrorClient = object : live.aem.koffetch.FFetchHTTPClient {
+                override suspend fun fetch(
+                    url: String,
+                    cacheConfig: live.aem.koffetch.FFetchCacheConfig,
+                ): Pair<String, io.ktor.client.statement.HttpResponse> {
+                    if (url.contains("docs/article")) {
+                        throw FFetchError.NetworkError(RuntimeException("Simulated network failure for $url"))
+                    }
+                    // For other URLs, delegate to the mock client
+                    return mockHttpClient.fetch(url, cacheConfig)
+                }
+            }
+
+            // Set up the base response
+            val initialResponse =
+                mockHttpClient.createAEMResponse(
+                    total = 1,
+                    offset = 0,
+                    limit = 255,
+                    data =
+                        listOf(
+                            mapOf(
+                                "path" to "/content/network-error",
+                                "title" to "Network Error Article",
+                                "documentUrl" to "https://example.com/docs/article.html",
+                            ),
+                        ),
+                )
+
+            mockHttpClient.setSuccessResponse(
+                "https://example.com/network-test.json?offset=0&limit=255",
+                initialResponse,
+            )
+
+            val ffetch =
+                FFetch(
+                    URL("https://example.com/network-test.json"),
+                    FFetchContext(
+                        httpClient = networkErrorClient,
+                        htmlParser = mockHtmlParser,
+                    ),
+                )
+
+            val results = ffetch.follow("documentUrl").asFlow().toList()
+
+            assertEquals(1, results.size)
+
+            val entry = results.first()
+            assertNull(entry["documentUrl"])
+            val error = entry["documentUrl_error"] as? String
+            assertTrue(error?.contains("Network error") == true)
+            assertTrue(error?.contains("Simulated network failure") == true)
+        }
+
+    @Test
+    fun testEdgeCaseUrlValidation() =
+        runTest {
+            val edgeCaseResponse =
+                mockHttpClient.createAEMResponse(
+                    total = 6,
+                    offset = 0,
+                    limit = 255,
+                    data =
+                        listOf(
+                            mapOf(
+                                "path" to "/content/whitespace",
+                                "title" to "Whitespace URL",
+                                "documentUrl" to "  \t\n  ", // Only whitespace
+                            ),
+                            mapOf(
+                                "path" to "/content/empty-string",
+                                "title" to "Empty URL",
+                                "documentUrl" to "", // Empty string
+                            ),
+                            mapOf(
+                                "path" to "/content/spaces-in-url",
+                                "title" to "Spaces in URL",
+                                "documentUrl" to "https://example.com/path with spaces.html",
+                            ),
+                            mapOf(
+                                "path" to "/content/malformed-protocol",
+                                "title" to "Malformed Protocol",
+                                "documentUrl" to "htp://example.com/doc.html", // Missing 't' in http
+                            ),
+                            mapOf(
+                                "path" to "/content/missing-hostname",
+                                "title" to "Missing Hostname",
+                                "documentUrl" to "https:///doc.html", // Missing hostname
+                            ),
+                            mapOf(
+                                "path" to "/content/path-only",
+                                "title" to "Path Only",
+                                "documentUrl" to "/absolute/path/to/doc.html", // Absolute path - should work
+                            ),
+                        ),
+                )
+
+            mockHttpClient.setSuccessResponse(
+                "https://example.com/edge-cases.json?offset=0&limit=255",
+                edgeCaseResponse,
+            )
+
+            mockHttpClient.setSuccessResponse(
+                "https://example.com/absolute/path/to/doc.html",
+                "<html><body><h1>Absolute Path Content</h1></body></html>",
+            )
+
+            val ffetch =
+                FFetch(
+                    URL("https://example.com/edge-cases.json"),
+                    FFetchContext(
+                        httpClient = mockHttpClient,
+                        htmlParser = mockHtmlParser,
+                    ),
+                )
+
+            val results = ffetch.follow("documentUrl").asFlow().toList()
+
+            assertEquals(6, results.size)
+
+            // Most should have URL resolution errors
+            val errorEntries = results.filter { it["path"] != "/content/path-only" }
+            errorEntries.forEach { entry ->
+                assertNull(entry["documentUrl"])
+                val error = entry["documentUrl_error"] as? String
+                assertTrue(
+                    error?.contains("Missing or invalid URL") == true ||
+                        error?.contains("Could not resolve URL") == true,
+                    "Expected URL error for ${entry["path"]}, got: $error",
+                )
+            }
+
+            // Absolute path should work
+            val pathOnlyEntry = results.first { it["path"] == "/content/path-only" }
+            assertNotNull(pathOnlyEntry["documentUrl"])
+            assertNull(pathOnlyEntry["documentUrl_error"])
+        }
+
+    @Test
+    fun testCustomFieldNameErrorPropagation() =
+        runTest {
+            val errorResponse =
+                mockHttpClient.createAEMResponse(
+                    total = 1,
+                    offset = 0,
+                    limit = 255,
+                    data =
+                        listOf(
+                            mapOf(
+                                "path" to "/content/custom-field-error",
+                                "title" to "Custom Field Error",
+                                "documentUrl" to "not-a-valid-url",
+                            ),
+                        ),
+                )
+
+            mockHttpClient.setSuccessResponse(
+                "https://example.com/custom-field.json?offset=0&limit=255",
+                errorResponse,
+            )
+
+            val ffetch =
+                FFetch(
+                    URL("https://example.com/custom-field.json"),
+                    FFetchContext(
+                        httpClient = mockHttpClient,
+                        htmlParser = mockHtmlParser,
+                    ),
+                )
+
+            val results = ffetch.follow("documentUrl", "customDocument").asFlow().toList()
+
+            assertEquals(1, results.size)
+
+            val entry = results.first()
+            assertNull(entry["customDocument"])
+            val error = entry["customDocument_error"] as? String
+            assertTrue(error?.contains("Could not resolve URL") == true)
+
+            // Original field should still exist
+            assertTrue(entry.containsKey("documentUrl"))
+            assertEquals("not-a-valid-url", entry["documentUrl"])
+        }
+
+    @Test
+    fun testProtocolEdgeCases() =
+        runTest {
+            val protocolResponse =
+                mockHttpClient.createAEMResponse(
+                    total = 3,
+                    offset = 0,
+                    limit = 255,
+                    data =
+                        listOf(
+                            mapOf(
+                                "path" to "/content/http-explicit",
+                                "title" to "HTTP Explicit",
+                                "documentUrl" to "http://insecure.example.com/doc.html",
+                            ),
+                            mapOf(
+                                "path" to "/content/https-explicit",
+                                "title" to "HTTPS Explicit",
+                                "documentUrl" to "https://secure.example.com/doc.html",
+                            ),
+                            mapOf(
+                                "path" to "/content/unknown-protocol",
+                                "title" to "Unknown Protocol",
+                                "documentUrl" to "ftp://files.example.com/doc.txt",
+                            ),
+                        ),
+                )
+
+            mockHttpClient.setSuccessResponse(
+                "https://example.com/protocols.json?offset=0&limit=255",
+                protocolResponse,
+            )
+
+            val ffetch =
+                FFetch(
+                    URL("https://example.com/protocols.json"),
+                    FFetchContext(
+                        httpClient = mockHttpClient,
+                        htmlParser = mockHtmlParser,
+                    ),
+                )
+
+            val results =
+                ffetch
+                    .allow(listOf("insecure.example.com", "secure.example.com", "files.example.com"))
+                    .follow("documentUrl")
+                    .asFlow()
+                    .toList()
+
+            assertEquals(3, results.size)
+
+            // FTP protocol should fail URL resolution
+            val ftpEntry = results.first { it["path"] == "/content/unknown-protocol" }
+            assertNull(ftpEntry["documentUrl"])
+            val error = ftpEntry["documentUrl_error"] as? String
+            assertTrue(error?.contains("Could not resolve URL") == true)
+        }
+
+    @Test
+    fun testNullHostnameHandling() =
+        runTest {
+            val nullHostResponse =
+                mockHttpClient.createAEMResponse(
+                    total = 1,
+                    offset = 0,
+                    limit = 255,
+                    data =
+                        listOf(
+                            mapOf(
+                                "path" to "/content/null-host",
+                                "title" to "Null Host",
+                                "documentUrl" to "file:///local/path/doc.html", // File URL with null host
+                            ),
+                        ),
+                )
+
+            mockHttpClient.setSuccessResponse(
+                "https://example.com/null-host.json?offset=0&limit=255",
+                nullHostResponse,
+            )
+
+            val ffetch =
+                FFetch(
+                    URL("https://example.com/null-host.json"),
+                    FFetchContext(
+                        httpClient = mockHttpClient,
+                        htmlParser = mockHtmlParser,
+                    ),
+                )
+
+            val results = ffetch.follow("documentUrl").asFlow().toList()
+
+            assertEquals(1, results.size)
+
+            val entry = results.first()
+            assertNull(entry["documentUrl"])
+            val error = entry["documentUrl_error"] as? String
+            assertTrue(error?.contains("unknown") == true || error?.contains("Could not resolve URL") == true)
         }
 
     private suspend fun Flow<FFetchEntry>.toList(): List<FFetchEntry> {


### PR DESCRIPTION
## Summary
- Adds extensive test coverage for hostname security restrictions in FFetch document following
- Tests allowlist functionality for specific, multiple, wildcard, and port-specific hostnames
- Includes tests for error handling scenarios: OutOfMemoryError, network errors, and URL validation edge cases
- Validates custom field name error propagation and protocol/hostname edge cases

## Changes

### Hostname Security Tests
- `testHostnameSecurityRestrictions`: Ensures cross-domain URLs are blocked by default
- `testAllowSpecificHostname`: Allows a single trusted hostname
- `testAllowMultipleHostnames`: Allows multiple trusted hostnames and blocks untrusted ones
- `testAllowAllHostnamesWithWildcard`: Allows all hostnames using wildcard
- `testPortSpecificHostnameValidation`: Validates hostname with specific allowed ports

### Error Handling Tests
- `testOutOfMemoryErrorHandling`: Simulates OutOfMemoryError during HTML parsing and verifies error propagation
- `testFFetchNetworkErrorHandling`: Simulates network errors during fetch and checks error reporting

### URL Validation and Edge Cases
- `testEdgeCaseUrlValidation`: Tests handling of whitespace, empty, malformed, missing hostname, and path-only URLs
- `testCustomFieldNameErrorPropagation`: Checks error propagation when using custom field names for document following
- `testProtocolEdgeCases`: Validates handling of unsupported protocols like FTP
- `testNullHostnameHandling`: Tests behavior with file URLs having null hostnames

## Test plan
- All new tests run with `runTest` coroutine test scope
- Assertions verify correct blocking, allowing, and error reporting for document following URLs
- Mock HTTP client and HTML parser used to simulate various scenarios
- Coverage ensures robustness of hostname security and error handling in FFetch document following feature

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/0c1e271a-7364-4fbd-888f-b81c581bf51a