### PR TITLE
Increase SecurityUtilsKt Test Coverage with Extensive HostnameSecurity Tests

### DIFF
--- a/src/test/kotlin/live/aem/koffetch/security/HostnameSecurityTest.kt
+++ b/src/test/kotlin/live/aem/koffetch/security/HostnameSecurityTest.kt
@@ -468,6 +468,252 @@ class HostnameSecurityTest {
             assertNull(entry["documentUrl_error"])
         }
 
+    @Test
+    fun testNullHostnameUrlHandling() =
+        runTest {
+            val response =
+                mockHttpClient.createAEMResponse(
+                    total = 1,
+                    offset = 0,
+                    limit = 255,
+                    data =
+                        listOf(
+                            mapOf(
+                                "path" to "/content/null-host",
+                                "title" to "Null Host Article",
+                                "documentUrl" to "file:///etc/passwd",
+                            ),
+                        ),
+                )
+
+            mockHttpClient.setSuccessResponse(
+                "https://example.com/null-host-test.json?offset=0&limit=255",
+                response,
+            )
+
+            val ffetch =
+                FFetch(
+                    URL("https://example.com/null-host-test.json"),
+                    FFetchContext(httpClient = mockHttpClient),
+                )
+
+            val results = ffetch.follow("documentUrl").asFlow().toList()
+
+            assertEquals(1, results.size)
+
+            val entry = results.first()
+            assertNull(entry["documentUrl"])
+            val error = entry["documentUrl_error"] as? String
+            assertNotNull(error)
+            assertTrue(error.contains("not allowed"))
+        }
+
+    @Test
+    fun testExplicitDefaultPortHandling() =
+        runTest {
+            val portResponse =
+                mockHttpClient.createAEMResponse(
+                    total = 2,
+                    offset = 0,
+                    limit = 255,
+                    data =
+                        listOf(
+                            mapOf(
+                                "path" to "/content/http-default-port",
+                                "title" to "HTTP Default Port Test",
+                                "documentUrl" to "http://example.com:80/doc1.html",
+                            ),
+                            mapOf(
+                                "path" to "/content/https-default-port",
+                                "title" to "HTTPS Default Port Test",
+                                "documentUrl" to "https://example.com:443/doc2.html",
+                            ),
+                        ),
+                )
+
+            mockHttpClient.setSuccessResponse(
+                "https://example.com/default-port-test.json?offset=0&limit=255",
+                portResponse,
+            )
+
+            mockHttpClient.setSuccessResponse(
+                "http://example.com:80/doc1.html",
+                "<html><body><h1>HTTP Default Port Document</h1></body></html>",
+            )
+
+            mockHttpClient.setSuccessResponse(
+                "https://example.com:443/doc2.html",
+                "<html><body><h1>HTTPS Default Port Document</h1></body></html>",
+            )
+
+            val ffetch =
+                FFetch(
+                    URL("https://example.com/default-port-test.json"),
+                    FFetchContext(httpClient = mockHttpClient),
+                )
+
+            val results = ffetch.follow("documentUrl").asFlow().toList()
+
+            assertEquals(2, results.size)
+
+            // Both should succeed as they use default ports (treated as hostname-only)
+            results.forEach { entry ->
+                assertNotNull(entry["documentUrl"])
+                assertNull(entry["documentUrl_error"])
+            }
+        }
+
+    @Test
+    fun testHttpProtocolHandling() =
+        runTest {
+            val httpResponse =
+                mockHttpClient.createAEMResponse(
+                    total = 1,
+                    offset = 0,
+                    limit = 255,
+                    data =
+                        listOf(
+                            mapOf(
+                                "path" to "/content/http-article",
+                                "title" to "HTTP Article",
+                                "documentUrl" to "http://example.com/doc.html",
+                            ),
+                        ),
+                )
+
+            mockHttpClient.setSuccessResponse(
+                "http://example.com/http-test.json?offset=0&limit=255",
+                httpResponse,
+            )
+
+            mockHttpClient.setSuccessResponse(
+                "http://example.com/doc.html",
+                "<html><body><h1>HTTP Document</h1></body></html>",
+            )
+
+            val ffetch =
+                FFetch(
+                    URL("http://example.com/http-test.json"),
+                    FFetchContext(httpClient = mockHttpClient),
+                )
+
+            val results = ffetch.follow("documentUrl").asFlow().toList()
+
+            assertEquals(1, results.size)
+
+            val entry = results.first()
+            // Same hostname should succeed even over HTTP
+            assertNotNull(entry["documentUrl"])
+            assertNull(entry["documentUrl_error"])
+        }
+
+    @Test
+    fun testUnsupportedProtocolHandling() =
+        runTest {
+            val response =
+                mockHttpClient.createAEMResponse(
+                    total = 3,
+                    offset = 0,
+                    limit = 255,
+                    data =
+                        listOf(
+                            mapOf(
+                                "path" to "/content/ftp-article",
+                                "title" to "FTP Article",
+                                "documentUrl" to "ftp://example.com/file.txt",
+                            ),
+                            mapOf(
+                                "path" to "/content/ldap-article",
+                                "title" to "LDAP Article",
+                                "documentUrl" to "ldap://example.com/query",
+                            ),
+                            mapOf(
+                                "path" to "/content/custom-article",
+                                "title" to "Custom Protocol Article",
+                                "documentUrl" to "custom://example.com/resource",
+                            ),
+                        ),
+                )
+
+            mockHttpClient.setSuccessResponse(
+                "https://example.com/protocol-test.json?offset=0&limit=255",
+                response,
+            )
+
+            val ffetch =
+                FFetch(
+                    URL("https://example.com/protocol-test.json"),
+                    FFetchContext(httpClient = mockHttpClient),
+                ).allow("example.com")
+
+            val results = ffetch.follow("documentUrl").asFlow().toList()
+
+            assertEquals(3, results.size)
+
+            // All unsupported protocols should be blocked
+            results.forEach { entry ->
+                assertNull(entry["documentUrl"])
+                val error = entry["documentUrl_error"] as? String
+                assertNotNull(error)
+                assertTrue(error.contains("not allowed"))
+            }
+        }
+
+    @Test
+    fun testCaseSensitiveProtocolHandling() =
+        runTest {
+            val response =
+                mockHttpClient.createAEMResponse(
+                    total = 2,
+                    offset = 0,
+                    limit = 255,
+                    data =
+                        listOf(
+                            mapOf(
+                                "path" to "/content/uppercase-http",
+                                "title" to "Uppercase HTTP",
+                                "documentUrl" to "HTTP://example.com/doc1.html",
+                            ),
+                            mapOf(
+                                "path" to "/content/mixed-case-https",
+                                "title" to "Mixed Case HTTPS",
+                                "documentUrl" to "HtTpS://example.com/doc2.html",
+                            ),
+                        ),
+                )
+
+            mockHttpClient.setSuccessResponse(
+                "https://example.com/case-test.json?offset=0&limit=255",
+                response,
+            )
+
+            mockHttpClient.setSuccessResponse(
+                "HTTP://example.com/doc1.html",
+                "<html><body><h1>Uppercase HTTP Document</h1></body></html>",
+            )
+
+            mockHttpClient.setSuccessResponse(
+                "HtTpS://example.com/doc2.html",
+                "<html><body><h1>Mixed Case HTTPS Document</h1></body></html>",
+            )
+
+            val ffetch =
+                FFetch(
+                    URL("https://example.com/case-test.json"),
+                    FFetchContext(httpClient = mockHttpClient),
+                )
+
+            val results = ffetch.follow("documentUrl").asFlow().toList()
+
+            assertEquals(2, results.size)
+
+            // Protocol matching should be case-insensitive
+            results.forEach { entry ->
+                assertNotNull(entry["documentUrl"])
+                assertNull(entry["documentUrl_error"])
+            }
+        }
+
     private suspend fun Flow<FFetchEntry>.toList(): List<FFetchEntry> {
         val list = mutableListOf<FFetchEntry>()
         collect { list.add(it) }


### PR DESCRIPTION
## Summary
- Adds comprehensive tests to `HostnameSecurityTest.kt` to improve coverage of security utilities
- Covers handling of null hostnames, explicit default ports, HTTP protocol, unsupported protocols, and case sensitivity in protocols

## Changes

### New Test Cases
- **Null Hostname URL Handling**: Verifies that URLs with null or disallowed hosts are blocked with appropriate errors
- **Explicit Default Port Handling**: Tests URLs with explicit default HTTP (80) and HTTPS (443) ports are allowed
- **HTTP Protocol Handling**: Confirms that HTTP URLs with the same hostname are permitted
- **Unsupported Protocol Handling**: Ensures unsupported protocols like FTP, LDAP, and custom schemes are blocked
- **Case Sensitive Protocol Handling**: Validates that protocol matching is case-insensitive (e.g., HTTP vs http)

### Test Infrastructure
- Uses mocked HTTP client responses to simulate various URL scenarios
- Employs Kotlin coroutines and flows for asynchronous test execution

## Test plan
- [x] Run all new tests to verify correct behavior of security hostname filtering
- [x] Confirm no regressions in existing security tests
- [x] Validate error messages for disallowed URLs
- [x] Ensure coverage metrics reflect added tests

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/148b4afc-7122-4c78-be12-60f6abebe924