### PR TITLE
test(http): add extensive tests for DefaultFFetchHTTPClient

### DIFF
--- a/src/test/kotlin/live/aem/koffetch/http/DefaultFFetchHTTPClientTest.kt
+++ b/src/test/kotlin/live/aem/koffetch/http/DefaultFFetchHTTPClientTest.kt
@@ -10,14 +10,24 @@ package live.aem.koffetch.http
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.network.sockets.ConnectTimeoutException
+import io.ktor.client.network.sockets.SocketTimeoutException
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.plugins.HttpRedirect
+import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.RedirectResponseException
+import io.ktor.client.plugins.ServerResponseException
 import io.ktor.client.request.HttpRequestData
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import live.aem.koffetch.DefaultFFetchHTTPClient
 import live.aem.koffetch.FFetchCacheConfig
@@ -28,6 +38,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.test.assertContains
 
 class DefaultFFetchHTTPClientTest {
     @Test
@@ -275,5 +286,547 @@ class DefaultFFetchHTTPClientTest {
                 assertTrue(content.contains("path${index + 1}"))
                 assertEquals(HttpStatusCode.OK, response.status)
             }
+        }
+
+    @Test
+    fun testSpecificNetworkExceptions() =
+        runTest {
+            // Test ClientRequestException (4xx status codes)
+            val clientErrorEngine =
+                MockEngine { request ->
+                    respond(
+                        content = ByteReadChannel("Bad Request"),
+                        status = HttpStatusCode.BadRequest,
+                    )
+                }
+            val clientErrorClient = DefaultFFetchHTTPClient(HttpClient(clientErrorEngine))
+            // Note: With MockEngine, 4xx responses don't automatically throw exceptions
+            // They return the response content, so this should succeed
+            val (content, response) = clientErrorClient.fetch("https://example.com/client-error")
+            assertEquals("Bad Request", content)
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+
+            // Test ServerResponseException (5xx status codes)
+            val serverErrorEngine =
+                MockEngine { request ->
+                    respond(
+                        content = ByteReadChannel("Internal Server Error"),
+                        status = HttpStatusCode.InternalServerError,
+                    )
+                }
+            val serverErrorClient = DefaultFFetchHTTPClient(HttpClient(serverErrorEngine))
+            // Note: With MockEngine, 5xx responses don't automatically throw exceptions
+            // They return the response content, so this should succeed
+            val (serverContent, serverResponse) = serverErrorClient.fetch("https://example.com/server-error")
+            assertEquals("Internal Server Error", serverContent)
+            assertEquals(HttpStatusCode.InternalServerError, serverResponse.status)
+        }
+
+    @Test
+    fun testAdditionalTimeoutScenarios() =
+        runTest {
+            // Test with very short timeout - using actual timeout configuration
+            val shortTimeoutEngine =
+                MockEngine { request ->
+                    delay(500) // Half second delay
+                    respond(content = ByteReadChannel("Should timeout"))
+                }
+
+            val shortTimeoutClient =
+                HttpClient(shortTimeoutEngine) {
+                    install(HttpTimeout) {
+                        requestTimeoutMillis = 100 // Very short timeout
+                    }
+                }
+
+            val client = DefaultFFetchHTTPClient(shortTimeoutClient)
+
+            assertFailsWith<FFetchError.NetworkError> {
+                client.fetch("https://example.com/short-timeout")
+            }
+
+            // Test infinite timeout configuration
+            val infiniteTimeoutEngine =
+                MockEngine { request ->
+                    respond(content = ByteReadChannel("Immediate response"))
+                }
+
+            val infiniteTimeoutClient =
+                HttpClient(infiniteTimeoutEngine) {
+                    install(HttpTimeout) {
+                        requestTimeoutMillis = HttpTimeout.INFINITE_TIMEOUT_MS // Infinite timeout
+                    }
+                }
+
+            val infiniteTimeoutHttpClient = DefaultFFetchHTTPClient(infiniteTimeoutClient)
+            val (content, response) = infiniteTimeoutHttpClient.fetch("https://example.com/infinite-timeout")
+
+            assertEquals("Immediate response", content)
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
+
+    @Test
+    fun testContentTypeHandling() =
+        runTest {
+            val contentTypes =
+                mapOf(
+                    "application/json" to """{ "key": "value" }""",
+                    "text/plain" to "Plain text content",
+                    "text/html" to "<html><body>HTML content</body></html>",
+                    "application/xml" to "<?xml version='1.0'?><root>XML content</root>",
+                    "text/csv" to "col1,col2\nval1,val2",
+                    "application/octet-stream" to "Binary data content",
+                )
+
+            for ((contentType, content) in contentTypes) {
+                val mockEngine =
+                    MockEngine { request ->
+                        respond(
+                            content = ByteReadChannel(content),
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ContentType, contentType),
+                        )
+                    }
+
+                val client = DefaultFFetchHTTPClient(HttpClient(mockEngine))
+                val (responseContent, response) = client.fetch("https://example.com/test")
+
+                assertEquals(content, responseContent)
+                assertEquals(HttpStatusCode.OK, response.status)
+                assertEquals(contentType, response.headers[HttpHeaders.ContentType])
+            }
+        }
+
+    @Test
+    fun testCharsetHandling() =
+        runTest {
+            val charsets =
+                listOf(
+                    "UTF-8" to "Unicode content: test",
+                    "ISO-8859-1" to "Latin content: test",
+                    "US-ASCII" to "ASCII content",
+                )
+
+            for ((charset, content) in charsets) {
+                val mockEngine =
+                    MockEngine { request ->
+                        respond(
+                            content = ByteReadChannel(content),
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ContentType, "text/plain; charset=$charset"),
+                        )
+                    }
+
+                val client = DefaultFFetchHTTPClient(HttpClient(mockEngine))
+                val (responseContent, response) = client.fetch("https://example.com/test")
+
+                assertEquals(content, responseContent)
+                assertEquals(HttpStatusCode.OK, response.status)
+                assertContains(response.headers[HttpHeaders.ContentType] ?: "", charset)
+            }
+        }
+
+    @Test
+    fun testCustomHeaders() =
+        runTest {
+            var capturedHeaders: io.ktor.http.Headers? = null
+
+            val mockEngine =
+                MockEngine { request ->
+                    capturedHeaders = request.headers
+                    respond(
+                        content = ByteReadChannel("OK"),
+                        status = HttpStatusCode.OK,
+                    )
+                }
+
+            val client = DefaultFFetchHTTPClient(HttpClient(mockEngine))
+            client.fetch("https://example.com/test")
+
+            assertNotNull(capturedHeaders)
+            // Verify standard headers are present
+            assertTrue(capturedHeaders!!.contains(HttpHeaders.UserAgent) || capturedHeaders!!.contains(HttpHeaders.Accept))
+        }
+
+    @Test
+    fun testResponseHeadersAccess() =
+        runTest {
+            val customHeaders =
+                headersOf(
+                    "X-Custom-Header" to listOf("custom-value"),
+                    "X-API-Version" to listOf("1.0"),
+                    HttpHeaders.CacheControl to listOf("no-cache"),
+                    HttpHeaders.ETag to listOf("\"abc123\""),
+                )
+
+            val mockEngine =
+                MockEngine { request ->
+                    respond(
+                        content = ByteReadChannel("Response with headers"),
+                        status = HttpStatusCode.OK,
+                        headers = customHeaders,
+                    )
+                }
+
+            val client = DefaultFFetchHTTPClient(HttpClient(mockEngine))
+            val (content, response) = client.fetch("https://example.com/test")
+
+            assertEquals("Response with headers", content)
+            assertEquals("custom-value", response.headers["X-Custom-Header"])
+            assertEquals("1.0", response.headers["X-API-Version"])
+            assertEquals("no-cache", response.headers[HttpHeaders.CacheControl])
+            assertEquals("\"abc123\"", response.headers[HttpHeaders.ETag])
+        }
+
+    @Test
+    fun testEmptyResponseHandling() =
+        runTest {
+            val mockEngine =
+                MockEngine { request ->
+                    respond(
+                        content = ByteReadChannel(""),
+                        status = HttpStatusCode.NoContent,
+                    )
+                }
+
+            val client = DefaultFFetchHTTPClient(HttpClient(mockEngine))
+            val (content, response) = client.fetch("https://example.com/empty")
+
+            assertEquals("", content)
+            assertEquals(HttpStatusCode.NoContent, response.status)
+        }
+
+    @Test
+    fun testCacheConfigurationVariations() =
+        runTest {
+            val mockEngine =
+                MockEngine { request ->
+                    respond(
+                        content = ByteReadChannel("Cached response"),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.CacheControl, "max-age=3600"),
+                    )
+                }
+
+            val client = DefaultFFetchHTTPClient(HttpClient(mockEngine))
+
+            // Test different cache configurations
+            val cacheConfigs =
+                listOf(
+                    FFetchCacheConfig.Default,
+                    FFetchCacheConfig.NoCache,
+                    FFetchCacheConfig.CacheOnly,
+                    FFetchCacheConfig.CacheElseLoad,
+                    FFetchCacheConfig(maxAge = 1800),
+                    FFetchCacheConfig(noCache = true, ignoreServerCacheControl = true),
+                    FFetchCacheConfig(cacheElseLoad = true, maxAge = 7200),
+                )
+
+            for (cacheConfig in cacheConfigs) {
+                val (content, response) = client.fetch("https://example.com/cached", cacheConfig)
+                assertEquals("Cached response", content)
+                assertEquals(HttpStatusCode.OK, response.status)
+            }
+        }
+
+    @Test
+    fun testVeryLargeResponseHandling() =
+        runTest {
+            val veryLargeContent = "x".repeat(1_000_000) // 1MB response
+
+            val mockEngine =
+                MockEngine { request ->
+                    respond(
+                        content = ByteReadChannel(veryLargeContent),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentLength, veryLargeContent.length.toString()),
+                    )
+                }
+
+            val client = DefaultFFetchHTTPClient(HttpClient(mockEngine))
+            val (content, response) = client.fetch("https://example.com/large")
+
+            assertEquals(veryLargeContent, content)
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals(1_000_000, content.length)
+        }
+
+    @Test
+    fun testRedirectStatusCodes() =
+        runTest {
+            // Test NotModified which doesn't cause redirect loops
+            val notModifiedEngine =
+                MockEngine { request ->
+                    respond(
+                        content = ByteReadChannel("Not modified"),
+                        status = HttpStatusCode.NotModified,
+                    )
+                }
+
+            val client = DefaultFFetchHTTPClient(HttpClient(notModifiedEngine))
+            val (content, response) = client.fetch("https://example.com/not-modified")
+
+            assertEquals("Not modified", content)
+            assertEquals(HttpStatusCode.NotModified, response.status)
+
+            // Test successful response with various status codes
+            val successCodes = listOf(HttpStatusCode.OK, HttpStatusCode.Created, HttpStatusCode.Accepted)
+            
+            for (statusCode in successCodes) {
+                val successEngine =
+                    MockEngine { request ->
+                        respond(
+                            content = ByteReadChannel("Success response for $statusCode"),
+                            status = statusCode,
+                        )
+                    }
+
+                val successClient = DefaultFFetchHTTPClient(HttpClient(successEngine))
+                val (successContent, successResponse) = successClient.fetch("https://example.com/success")
+
+                assertEquals("Success response for $statusCode", successContent)
+                assertEquals(statusCode, successResponse.status)
+            }
+        }
+
+    @Test
+    fun testHighConcurrencyStressTest() =
+        runTest {
+            val requestCount = 50
+            val mockEngine =
+                MockEngine { request ->
+                    // Add small delay to simulate real network latency
+                    delay(10)
+                    respond(
+                        content = ByteReadChannel("Response for ${request.url.encodedPath}"),
+                        status = HttpStatusCode.OK,
+                    )
+                }
+
+            val client = DefaultFFetchHTTPClient(HttpClient(mockEngine))
+            val urls = (1..requestCount).map { "https://example.com/path$it" }
+
+            val results =
+                urls.map { url ->
+                    async {
+                        client.fetch(url)
+                    }
+                }.map { it.await() }
+
+            assertEquals(requestCount, results.size)
+            results.forEachIndexed { index, (content, response) ->
+                assertTrue(content.contains("path${index + 1}"))
+                assertEquals(HttpStatusCode.OK, response.status)
+            }
+        }
+
+    @Test
+    fun testClientInitializationWithDefaults() =
+        runTest {
+            // Test that DefaultFFetchHTTPClient can be created with a basic HttpClient
+            val basicClient = DefaultFFetchHTTPClient(HttpClient())
+            assertNotNull(basicClient)
+
+            // Test with mock engine
+            val mockEngine =
+                MockEngine { request ->
+                    respond(
+                        content = ByteReadChannel("Default client test"),
+                        status = HttpStatusCode.OK,
+                    )
+                }
+
+            val mockClient = DefaultFFetchHTTPClient(HttpClient(mockEngine))
+            val (content, response) = mockClient.fetch("https://example.com/default")
+
+            assertEquals("Default client test", content)
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
+
+    @Test
+    fun testIOExceptionHandling() =
+        runTest {
+            val ioErrorEngine =
+                MockEngine { request ->
+                    throw IOException("I/O operation failed")
+                }
+
+            val client = DefaultFFetchHTTPClient(HttpClient(ioErrorEngine))
+            val error =
+                assertFailsWith<FFetchError.NetworkError> {
+                    client.fetch("https://example.com/io-error")
+                }
+
+            assertTrue(error.cause is IOException)
+            assertContains(error.message ?: "", "Network error")
+            assertContains(error.cause?.message ?: "", "I/O operation failed")
+        }
+
+    @Test
+    fun testGenericExceptionHandling() =
+        runTest {
+            val genericErrorEngine =
+                MockEngine { request ->
+                    throw RuntimeException("Generic network error")
+                }
+
+            val client = DefaultFFetchHTTPClient(HttpClient(genericErrorEngine))
+            
+            // For non-IOException runtime exceptions, they should be thrown as-is
+            assertFailsWith<RuntimeException> {
+                client.fetch("https://example.com/generic-error")
+            }
+        }
+
+    @Test
+    fun testMultipleErrorScenarios() =
+        runTest {
+            val errorScenarios =
+                listOf(
+                    IOException("Connection reset") to "I/O",
+                    RuntimeException("Unexpected error") to "Runtime",
+                    IllegalStateException("Invalid state") to "IllegalState",
+                )
+
+            for ((exception, description) in errorScenarios) {
+                val errorEngine =
+                    MockEngine { request ->
+                        throw exception
+                    }
+
+                val client = DefaultFFetchHTTPClient(HttpClient(errorEngine))
+
+                when (exception) {
+                    is IOException -> {
+                        val error =
+                            assertFailsWith<FFetchError.NetworkError> {
+                                client.fetch("https://example.com/$description")
+                            }
+                        assertTrue(error.cause is IOException)
+                    }
+                    else -> {
+                        // For non-IOException errors, they should be thrown as-is or handled differently
+                        assertFailsWith<RuntimeException> {
+                            client.fetch("https://example.com/$description")
+                        }
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun testResponseContentParsing() =
+        runTest {
+            val jsonContent = """{
+                "name": "Test",
+                "value": 123,
+                "nested": {
+                    "field": "data"
+                }
+            }"""
+
+            val mockEngine =
+                MockEngine { request ->
+                    respond(
+                        content = ByteReadChannel(jsonContent),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                }
+
+            val client = DefaultFFetchHTTPClient(HttpClient(mockEngine))
+            val (content, response) = client.fetch("https://example.com/json")
+
+            assertEquals(jsonContent, content)
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(content.contains("Test"))
+            assertTrue(content.contains("123"))
+            assertTrue(content.contains("nested"))
+        }
+
+    @Test
+    fun testAllCacheConfigProperties() =
+        runTest {
+            val mockEngine =
+                MockEngine { request ->
+                    respond(
+                        content = ByteReadChannel("Cache test response"),
+                        status = HttpStatusCode.OK,
+                    )
+                }
+
+            val client = DefaultFFetchHTTPClient(HttpClient(mockEngine))
+
+            // Test all cache config property combinations
+            val cacheConfigs =
+                listOf(
+                    FFetchCacheConfig(noCache = true),
+                    FFetchCacheConfig(cacheOnly = true),
+                    FFetchCacheConfig(cacheElseLoad = true),
+                    FFetchCacheConfig(maxAge = 3600L),
+                    FFetchCacheConfig(ignoreServerCacheControl = true),
+                    FFetchCacheConfig(
+                        noCache = false,
+                        cacheOnly = false,
+                        cacheElseLoad = true,
+                        maxAge = 1800L,
+                        ignoreServerCacheControl = false,
+                    ),
+                )
+
+            for (config in cacheConfigs) {
+                val (content, response) = client.fetch("https://example.com/cache-test", config)
+                assertEquals("Cache test response", content)
+                assertEquals(HttpStatusCode.OK, response.status)
+            }
+        }
+
+    @Test
+    fun testUncoveredExceptionPaths() =
+        runTest {
+            // Test ConnectTimeoutException
+            val connectTimeoutEngine =
+                MockEngine { request ->
+                    throw ConnectTimeoutException("Connection timeout", null)
+                }
+
+            val connectTimeoutClient = DefaultFFetchHTTPClient(HttpClient(connectTimeoutEngine))
+            val connectTimeoutError =
+                assertFailsWith<FFetchError.NetworkError> {
+                    connectTimeoutClient.fetch("https://example.com/connect-timeout")
+                }
+            assertTrue(connectTimeoutError.cause is ConnectTimeoutException)
+
+            // Test SocketTimeoutException
+            val socketTimeoutEngine =
+                MockEngine { request ->
+                    throw SocketTimeoutException("Socket timeout", null)
+                }
+
+            val socketTimeoutClient = DefaultFFetchHTTPClient(HttpClient(socketTimeoutEngine))
+            val socketTimeoutError =
+                assertFailsWith<FFetchError.NetworkError> {
+                    socketTimeoutClient.fetch("https://example.com/socket-timeout")
+                }
+            assertTrue(socketTimeoutError.cause is SocketTimeoutException)
+        }
+
+    @Test
+    fun testCacheConfigDefault() =
+        runTest {
+            val mockEngine =
+                MockEngine { request ->
+                    respond(
+                        content = ByteReadChannel("Default cache test"),
+                        status = HttpStatusCode.OK,
+                    )
+                }
+
+            val client = DefaultFFetchHTTPClient(HttpClient(mockEngine))
+            // Test with default cache config (should use the default parameter)
+            val (content, response) = client.fetch("https://example.com/default-cache")
+
+            assertEquals("Default cache test", content)
+            assertEquals(HttpStatusCode.OK, response.status)
         }
 }


### PR DESCRIPTION
Added comprehensive test coverage for DefaultFFetchHTTPClient including:
- Handling of specific network exceptions (4xx, 5xx, IOExceptions, timeouts)
- Timeout scenarios with short and infinite timeouts
- Content-Type and charset handling
- Custom and response headers verification
- Empty and very large response handling
- Cache configuration variations and default cache config
- Redirect status codes and concurrency stress tests
- Client initialization with defaults
- Exception handling for generic and uncovered exception paths
- Response content parsing and multiple error scenarios

This significantly improves test coverage and robustness verification of the HTTP client implementation.