### PR TITLE
Fix ktlint issues by adjusting comment formatting in test files

### DIFF
--- a/src/test/kotlin/live/aem/koffetch/FFetchContextLegacyTest.kt
+++ b/src/test/kotlin/live/aem/koffetch/FFetchContextLegacyTest.kt
@@ -293,7 +293,8 @@ class FFetchContextLegacyTest {
         val complexCacheConfig =
             FFetchCacheConfig(
                 noCache = true,
-                cacheOnly = true, // contradictory but allowed
+                // contradictory but allowed
+                cacheOnly = true,
                 cacheElseLoad = true,
                 maxAge = 0,
                 ignoreServerCacheControl = true,

--- a/src/test/kotlin/live/aem/koffetch/extensions/FFetchDocumentFollowingTest.kt
+++ b/src/test/kotlin/live/aem/koffetch/extensions/FFetchDocumentFollowingTest.kt
@@ -1011,12 +1011,14 @@ class FFetchDocumentFollowingTest {
                             mapOf(
                                 "path" to "/content/whitespace",
                                 "title" to "Whitespace URL",
-                                "documentUrl" to "  \t\n  ", // Only whitespace
+                                // Only whitespace
+                                "documentUrl" to "  \t\n  ",
                             ),
                             mapOf(
                                 "path" to "/content/empty-string",
                                 "title" to "Empty URL",
-                                "documentUrl" to "", // Empty string
+                                // Empty string
+                                "documentUrl" to "",
                             ),
                             mapOf(
                                 "path" to "/content/spaces-in-url",
@@ -1026,17 +1028,20 @@ class FFetchDocumentFollowingTest {
                             mapOf(
                                 "path" to "/content/malformed-protocol",
                                 "title" to "Malformed Protocol",
-                                "documentUrl" to "htp://example.com/doc.html", // Missing 't' in http
+                                // Missing 't' in http
+                                "documentUrl" to "htp://example.com/doc.html",
                             ),
                             mapOf(
                                 "path" to "/content/missing-hostname",
                                 "title" to "Missing Hostname",
-                                "documentUrl" to "https:///doc.html", // Missing hostname
+                                // Missing hostname
+                                "documentUrl" to "https:///doc.html",
                             ),
                             mapOf(
                                 "path" to "/content/path-only",
                                 "title" to "Path Only",
-                                "documentUrl" to "/absolute/path/to/doc.html", // Absolute path - should work
+                                // Absolute path - should work
+                                "documentUrl" to "/absolute/path/to/doc.html",
                             ),
                         ),
                 )
@@ -1200,7 +1205,8 @@ class FFetchDocumentFollowingTest {
                             mapOf(
                                 "path" to "/content/null-host",
                                 "title" to "Null Host",
-                                "documentUrl" to "file:///local/path/doc.html", // File URL with null host
+                                // File URL with null host
+                                "documentUrl" to "file:///local/path/doc.html",
                             ),
                         ),
                 )


### PR DESCRIPTION
## Summary
- Resolves ktlint formatting issues in test files by adjusting comment placement
- Improves code readability and consistency in FFetchContextLegacyTest.kt and FFetchDocumentFollowingTest.kt

## Changes

### FFetchContextLegacyTest.kt
- Moved inline comment above the `cacheOnly` property to comply with ktlint rules

### FFetchDocumentFollowingTest.kt
- Moved inline comments above the `documentUrl` map entries to separate lines
- Ensures comments are properly formatted and do not violate ktlint rules

## Test plan
- [x] Verified that tests in both modified files run successfully
- [x] Confirmed no ktlint warnings or errors after changes
- [x] Reviewed code formatting for consistency and clarity

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/0d2b06f9-fd3b-40cf-b550-813f4ed5dc88