### PR TITLE
Add comprehensive tests for FFetchContext config setters and copyWithConfigs

### DIFF
--- a/src/test/kotlin/live/aem/koffetch/FFetchContextLegacyTest.kt
+++ b/src/test/kotlin/live/aem/koffetch/FFetchContextLegacyTest.kt
@@ -377,4 +377,36 @@ class FFetchContextLegacyTest {
         assertEquals(originalParams.maxConcurrency, roundTripParams.maxConcurrency)
         assertEquals(originalParams.allowedHosts, roundTripParams.allowedHosts)
     }
+
+    @Test
+    fun `test FFetchContext setClientConfig and setSecurityConfig`() {
+        val context = FFetchContext()
+        
+        // Test initial state
+        val initialClientConfig = context.clientConfig
+        val initialSecurityConfig = context.securityConfig
+        
+        // Create new configs
+        val newClient = MockFFetchHTTPClient()
+        val newParser = MockHTMLParser()
+        val newClientConfig = FFetchClientConfig(newClient, newParser)
+        
+        val newHosts = mutableSetOf("test1.com", "test2.com")
+        val newSecurityConfig = FFetchSecurityConfig(newHosts)
+        
+        // Set new configs directly
+        context.clientConfig = newClientConfig
+        context.securityConfig = newSecurityConfig
+        
+        // Verify configs were updated
+        assertEquals(newClientConfig, context.clientConfig)
+        assertEquals(newSecurityConfig, context.securityConfig)
+        assertNotSame(initialClientConfig, context.clientConfig)
+        assertNotSame(initialSecurityConfig, context.securityConfig)
+        
+        // Verify delegation still works
+        assertEquals(newClient, context.httpClient)
+        assertEquals(newParser, context.htmlParser)
+        assertEquals(newHosts, context.allowedHosts)
+    }
 }

--- a/src/test/kotlin/live/aem/koffetch/FFetchContextLegacyTest.kt
+++ b/src/test/kotlin/live/aem/koffetch/FFetchContextLegacyTest.kt
@@ -381,29 +381,29 @@ class FFetchContextLegacyTest {
     @Test
     fun `test FFetchContext setClientConfig and setSecurityConfig`() {
         val context = FFetchContext()
-        
+
         // Test initial state
         val initialClientConfig = context.clientConfig
         val initialSecurityConfig = context.securityConfig
-        
+
         // Create new configs
         val newClient = MockFFetchHTTPClient()
         val newParser = MockHTMLParser()
         val newClientConfig = FFetchClientConfig(newClient, newParser)
-        
+
         val newHosts = mutableSetOf("test1.com", "test2.com")
         val newSecurityConfig = FFetchSecurityConfig(newHosts)
-        
+
         // Set new configs directly
         context.clientConfig = newClientConfig
         context.securityConfig = newSecurityConfig
-        
+
         // Verify configs were updated
         assertEquals(newClientConfig, context.clientConfig)
         assertEquals(newSecurityConfig, context.securityConfig)
         assertNotSame(initialClientConfig, context.clientConfig)
         assertNotSame(initialSecurityConfig, context.securityConfig)
-        
+
         // Verify delegation still works
         assertEquals(newClient, context.httpClient)
         assertEquals(newParser, context.htmlParser)

--- a/src/test/kotlin/live/aem/koffetch/FFetchContextTest.kt
+++ b/src/test/kotlin/live/aem/koffetch/FFetchContextTest.kt
@@ -408,14 +408,14 @@ class FFetchContextTest {
     fun `test setClientConfig method`() {
         val context = FFetchContext()
         val originalConfig = context.clientConfig
-        
+
         val newClient = MockFFetchHTTPClient()
         val newParser = MockHTMLParser()
         val newClientConfig = FFetchClientConfig(newClient, newParser)
-        
+
         // Test setting new client config
         context.clientConfig = newClientConfig
-        
+
         // Verify the config was updated
         assertEquals(newClientConfig, context.clientConfig)
         assertEquals(newClient, context.httpClient)
@@ -427,13 +427,13 @@ class FFetchContextTest {
     fun `test setSecurityConfig method`() {
         val context = FFetchContext()
         val originalConfig = context.securityConfig
-        
+
         val newHosts = mutableSetOf("secure1.com", "secure2.com", "secure3.com")
         val newSecurityConfig = FFetchSecurityConfig(newHosts)
-        
+
         // Test setting new security config
         context.securityConfig = newSecurityConfig
-        
+
         // Verify the config was updated
         assertEquals(newSecurityConfig, context.securityConfig)
         assertEquals(newHosts, context.allowedHosts)
@@ -445,18 +445,19 @@ class FFetchContextTest {
 
     @Test
     fun `test copyWithConfigs default parameters`() {
-        val original = FFetchContext(
-            chunkSize = 100,
-            maxConcurrency = 10,
-            cacheReload = true,
-            sheetName = "test",
-            total = 500
-        )
+        val original =
+            FFetchContext(
+                chunkSize = 100,
+                maxConcurrency = 10,
+                cacheReload = true,
+                sheetName = "test",
+                total = 500,
+            )
         original.allowedHosts.add("original.com")
-        
+
         // Test copyWithConfigs with no parameters (all defaults)
         val copied = original.copyWithConfigs()
-        
+
         // Verify all values are preserved
         assertEquals(100, copied.chunkSize)
         assertEquals(10, copied.maxConcurrency)
@@ -464,7 +465,7 @@ class FFetchContextTest {
         assertEquals("test", copied.sheetName)
         assertEquals(500, copied.total)
         assertTrue(copied.allowedHosts.contains("original.com"))
-        
+
         // Verify configs are same objects
         assertEquals(original.performanceConfig, copied.performanceConfig)
         assertEquals(original.clientConfig, copied.clientConfig)
@@ -477,21 +478,22 @@ class FFetchContextTest {
         val customClient = MockFFetchHTTPClient()
         val customParser = MockHTMLParser()
         val customHosts = mutableSetOf("legacy1.com", "legacy2.com")
-        
-        val legacyParams = FFetchContext.LegacyParams(
-            chunkSize = 150,
-            cacheReload = true,
-            cacheConfig = FFetchCacheConfig.NoCache,
-            sheetName = "legacy",
-            httpClient = customClient,
-            htmlParser = customParser,
-            total = 1500,
-            maxConcurrency = 15,
-            allowedHosts = customHosts
-        )
-        
+
+        val legacyParams =
+            FFetchContext.LegacyParams(
+                chunkSize = 150,
+                cacheReload = true,
+                cacheConfig = FFetchCacheConfig.NoCache,
+                sheetName = "legacy",
+                httpClient = customClient,
+                htmlParser = customParser,
+                total = 1500,
+                maxConcurrency = 15,
+                allowedHosts = customHosts,
+            )
+
         val context = FFetchContext.create(legacyParams)
-        
+
         // Verify all parameters were set correctly
         assertEquals(150, context.chunkSize)
         assertTrue(context.cacheReload)
@@ -507,22 +509,23 @@ class FFetchContextTest {
     @Test
     fun `test FFetchContext companion object createLegacy method`() {
         val customClient = MockFFetchHTTPClient()
-        
-        val context = FFetchContext.createLegacy(
-            chunkSize = 200,
-            cacheReload = true,
-            cacheConfig = FFetchCacheConfig.CacheOnly,
-            sheetName = "legacy-create",
-            httpClient = customClient
-        )
-        
+
+        val context =
+            FFetchContext.createLegacy(
+                chunkSize = 200,
+                cacheReload = true,
+                cacheConfig = FFetchCacheConfig.CacheOnly,
+                sheetName = "legacy-create",
+                httpClient = customClient,
+            )
+
         // Verify all parameters were set correctly
         assertEquals(200, context.chunkSize)
         assertTrue(context.cacheReload)
         assertEquals(FFetchCacheConfig.CacheOnly, context.cacheConfig)
         assertEquals("legacy-create", context.sheetName)
         assertEquals(customClient, context.httpClient)
-        
+
         // Verify defaults were applied for unspecified parameters
         assertEquals(5, context.maxConcurrency) // default
         assertNull(context.total) // default
@@ -533,21 +536,21 @@ class FFetchContextTest {
     fun `test copyWithConfigs with partial parameters preserves unspecified configs`() {
         val original = FFetchContext()
         original.allowedHosts.add("test.com")
-        
+
         // Only change performance config
         val newPerfConfig = FFetchPerformanceConfig(chunkSize = 999, maxConcurrency = 99)
         val copied = original.copyWithConfigs(performanceConfig = newPerfConfig)
-        
+
         // Verify performance config changed
         assertEquals(999, copied.chunkSize)
         assertEquals(99, copied.maxConcurrency)
-        
+
         // Verify other configs preserved
         assertEquals(original.cacheReload, copied.cacheReload)
         assertEquals(original.cacheConfig, copied.cacheConfig)
         assertEquals(original.clientConfig, copied.clientConfig)
         assertEquals(original.requestConfig, copied.requestConfig)
-        
+
         // Verify security config is a copy
         assertTrue(copied.allowedHosts.contains("test.com"))
         copied.allowedHosts.add("new.com")

--- a/src/test/kotlin/live/aem/koffetch/FFetchContextTest.kt
+++ b/src/test/kotlin/live/aem/koffetch/FFetchContextTest.kt
@@ -403,4 +403,154 @@ class FFetchContextTest {
         val nullContext = FFetchContext(sheetName = null)
         assertNull(nullContext.sheetName)
     }
+
+    @Test
+    fun `test setClientConfig method`() {
+        val context = FFetchContext()
+        val originalConfig = context.clientConfig
+        
+        val newClient = MockFFetchHTTPClient()
+        val newParser = MockHTMLParser()
+        val newClientConfig = FFetchClientConfig(newClient, newParser)
+        
+        // Test setting new client config
+        context.clientConfig = newClientConfig
+        
+        // Verify the config was updated
+        assertEquals(newClientConfig, context.clientConfig)
+        assertEquals(newClient, context.httpClient)
+        assertEquals(newParser, context.htmlParser)
+        assertNotSame(originalConfig, context.clientConfig)
+    }
+
+    @Test
+    fun `test setSecurityConfig method`() {
+        val context = FFetchContext()
+        val originalConfig = context.securityConfig
+        
+        val newHosts = mutableSetOf("secure1.com", "secure2.com", "secure3.com")
+        val newSecurityConfig = FFetchSecurityConfig(newHosts)
+        
+        // Test setting new security config
+        context.securityConfig = newSecurityConfig
+        
+        // Verify the config was updated
+        assertEquals(newSecurityConfig, context.securityConfig)
+        assertEquals(newHosts, context.allowedHosts)
+        assertTrue(context.allowedHosts.contains("secure1.com"))
+        assertTrue(context.allowedHosts.contains("secure2.com"))
+        assertTrue(context.allowedHosts.contains("secure3.com"))
+        assertNotSame(originalConfig, context.securityConfig)
+    }
+
+    @Test
+    fun `test copyWithConfigs default parameters`() {
+        val original = FFetchContext(
+            chunkSize = 100,
+            maxConcurrency = 10,
+            cacheReload = true,
+            sheetName = "test",
+            total = 500
+        )
+        original.allowedHosts.add("original.com")
+        
+        // Test copyWithConfigs with no parameters (all defaults)
+        val copied = original.copyWithConfigs()
+        
+        // Verify all values are preserved
+        assertEquals(100, copied.chunkSize)
+        assertEquals(10, copied.maxConcurrency)
+        assertTrue(copied.cacheReload)
+        assertEquals("test", copied.sheetName)
+        assertEquals(500, copied.total)
+        assertTrue(copied.allowedHosts.contains("original.com"))
+        
+        // Verify configs are same objects
+        assertEquals(original.performanceConfig, copied.performanceConfig)
+        assertEquals(original.clientConfig, copied.clientConfig)
+        assertEquals(original.requestConfig, copied.requestConfig)
+        assertEquals(original.cacheConfig, copied.cacheConfig)
+    }
+
+    @Test
+    fun `test FFetchContext companion object create method`() {
+        val customClient = MockFFetchHTTPClient()
+        val customParser = MockHTMLParser()
+        val customHosts = mutableSetOf("legacy1.com", "legacy2.com")
+        
+        val legacyParams = FFetchContext.LegacyParams(
+            chunkSize = 150,
+            cacheReload = true,
+            cacheConfig = FFetchCacheConfig.NoCache,
+            sheetName = "legacy",
+            httpClient = customClient,
+            htmlParser = customParser,
+            total = 1500,
+            maxConcurrency = 15,
+            allowedHosts = customHosts
+        )
+        
+        val context = FFetchContext.create(legacyParams)
+        
+        // Verify all parameters were set correctly
+        assertEquals(150, context.chunkSize)
+        assertTrue(context.cacheReload)
+        assertEquals(FFetchCacheConfig.NoCache, context.cacheConfig)
+        assertEquals("legacy", context.sheetName)
+        assertEquals(customClient, context.httpClient)
+        assertEquals(customParser, context.htmlParser)
+        assertEquals(1500, context.total)
+        assertEquals(15, context.maxConcurrency)
+        assertEquals(customHosts, context.allowedHosts)
+    }
+
+    @Test
+    fun `test FFetchContext companion object createLegacy method`() {
+        val customClient = MockFFetchHTTPClient()
+        
+        val context = FFetchContext.createLegacy(
+            chunkSize = 200,
+            cacheReload = true,
+            cacheConfig = FFetchCacheConfig.CacheOnly,
+            sheetName = "legacy-create",
+            httpClient = customClient
+        )
+        
+        // Verify all parameters were set correctly
+        assertEquals(200, context.chunkSize)
+        assertTrue(context.cacheReload)
+        assertEquals(FFetchCacheConfig.CacheOnly, context.cacheConfig)
+        assertEquals("legacy-create", context.sheetName)
+        assertEquals(customClient, context.httpClient)
+        
+        // Verify defaults were applied for unspecified parameters
+        assertEquals(5, context.maxConcurrency) // default
+        assertNull(context.total) // default
+        assertTrue(context.allowedHosts.isEmpty()) // default
+    }
+
+    @Test
+    fun `test copyWithConfigs with partial parameters preserves unspecified configs`() {
+        val original = FFetchContext()
+        original.allowedHosts.add("test.com")
+        
+        // Only change performance config
+        val newPerfConfig = FFetchPerformanceConfig(chunkSize = 999, maxConcurrency = 99)
+        val copied = original.copyWithConfigs(performanceConfig = newPerfConfig)
+        
+        // Verify performance config changed
+        assertEquals(999, copied.chunkSize)
+        assertEquals(99, copied.maxConcurrency)
+        
+        // Verify other configs preserved
+        assertEquals(original.cacheReload, copied.cacheReload)
+        assertEquals(original.cacheConfig, copied.cacheConfig)
+        assertEquals(original.clientConfig, copied.clientConfig)
+        assertEquals(original.requestConfig, copied.requestConfig)
+        
+        // Verify security config is a copy
+        assertTrue(copied.allowedHosts.contains("test.com"))
+        copied.allowedHosts.add("new.com")
+        assertFalse(original.allowedHosts.contains("new.com"))
+    }
 }


### PR DESCRIPTION
## Summary
- Adds extensive unit tests for `FFetchContext` configuration setters
- Tests `setClientConfig` and `setSecurityConfig` methods for proper updates and delegation
- Validates `copyWithConfigs` method behavior with default and partial parameters
- Covers companion object factory methods `create` and `createLegacy` for correct parameter application

## Changes

### FFetchContextLegacyTest.kt
- Added test to verify setting `clientConfig` and `securityConfig` updates internal state and delegates correctly

### FFetchContextTest.kt
- Added tests for `setClientConfig` and `setSecurityConfig` methods ensuring config updates and delegation
- Added tests for `copyWithConfigs` method:
  - Default parameters preserve all original config values
  - Partial parameters update specified configs while preserving others
- Added tests for companion object factory methods:
  - `create` method sets all parameters correctly from legacy params
  - `createLegacy` method applies parameters and defaults correctly

## Test plan
- All new tests added under `FFetchContextLegacyTest` and `FFetchContextTest` classes
- Verified config updates, delegation, and copying behavior
- Ensured no regressions in config handling and factory methods

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e50d6382-896f-494c-a846-5f0cdb26f4ca